### PR TITLE
Issue 21 | Add support for SGP30

### DIFF
--- a/.github/workflows/arduino.yaml
+++ b/.github/workflows/arduino.yaml
@@ -28,5 +28,9 @@ jobs:
         run: |
           arduino-cli lib install "ESP8266 and ESP32 OLED driver for SSD1306 displays"
 
+      - name: Install SGP30 Sensor Library
+        run: |
+          arduino-cli lib install "SGP30"
+
       - name: Compile Sketch
         run: arduino-cli compile --fqbn esp8266:esp8266:d1_mini ./AirGradient-DIY

--- a/AirGradient-DIY/AirGradient-DIY.ino
+++ b/AirGradient-DIY/AirGradient-DIY.ino
@@ -195,7 +195,7 @@ String GenerateMetrics() {
 
     message += "# HELP eth Ethanol\n";
     message += "# TYPE eth gauge\n";
-    message += "tvoc";
+    message += "eth";
     message += idString;
     message += String(ETHstat);
     message += "\n";


### PR DESCRIPTION
### What was changed?

Added in support for SGP30 sensor based on the following AirGradient doc:

https://www.airgradient.com/resources/tvoc-on-airgradient-diy-sensor/

Sensor can be enabled from line 27 setting the flag to True. As well changing the Serial speed from 9600 to 115200

Requires the additional install of the SGP30 Arduino library by RobTillaart