### PR TITLE
Removed CI reference from old repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # AirGradient - Prometheus WiFi Sketch
 
-[![CI](https://github.com/geerlingguy/airgradient-prometheus/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/geerlingguy/airgradient-prometheus/actions/workflows/ci.yml)
-
 AirGradient has a [DIY air sensor](https://www.airgradient.com/diy/). I built one (actually, more than one). I want to integrate sensor data into my in-home Prometheus instance and graph the data in Grafana.
 
 So I built this.


### PR DESCRIPTION
.github/workflows/ci.yml was removed in commit 144e985. There is no need to reference it in current readme.