### PR TITLE
Add ESPHome support for the AirGradient DIY Pro kit

### DIFF
--- a/AirGradient-ESPHome/README.md
+++ b/AirGradient-ESPHome/README.md
@@ -38,6 +38,8 @@ esphome run airgradient-diy.yaml --device /dev/tty.usbserial-410
 
 This should compile, flash, and run the configuration, and leave the logged output in your console. When you're satisfied things are working correctly, you can press Ctrl+C to exit the logs, and your AirGradient will continue running. You can now place it wherever you'd like.
 
+If you have the [AirGradient DIY Pro kit](https://www.airgradient.com/open-airgradient/instructions/diy-pro/), you can use the `airgradient-diy-pro.yaml` configuration.
+
 > You can do this setup from within the ESPHome Dashboard inside Home Assistant, but that installation method is not described here.
 
 ### Static IP address

--- a/AirGradient-ESPHome/airgradient-diy-pro.yaml
+++ b/AirGradient-ESPHome/airgradient-diy-pro.yaml
@@ -1,0 +1,121 @@
+---
+# Adapted from: https://github.com/m-reiner/airgradient-esphome-prometheus
+esphome:
+  name: !secret name
+  platform: ESP8266
+  board: d1_mini
+
+logger:
+
+api:
+  password: !secret api_password
+
+ota:
+  password: !secret ota_password
+
+# See: https://community.home-assistant.io/t/esphome-flashing-over-wifi-does-not-work/357352
+switch:
+  - platform: safe_mode
+    name: "Flash Mode (Safe Mode)"
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  fast_connect: true
+# To use a static IP, uncomment this block of configuration:
+#  manual_ip:
+#    static_ip: PleaseChangeMe
+#    gateway: PleaseChangeMe
+#    subnet: 255.255.255.0
+
+text_sensor:
+  - platform: wifi_info
+    ip_address:
+      name: ESP IP Address
+      id: esp_ip_address
+
+i2c:
+  sda: D2
+  scl: D1
+  frequency: 800kHz # See: https://github.com/esphome/issues/issues/3106#issuecomment-1056974042
+
+font:
+  - file: "gfonts://Arimo@Regular"
+    id: arimo10
+    size: 10
+
+display:
+  - platform: ssd1306_i2c
+    id: oled
+    model: "SH1106 128x64"
+    rotation: 180
+    pages:
+      - id: page1
+        lambda: |-
+          it.printf(0, 0, id(arimo10), "%s", id(esp_ip_address).state.c_str());
+          it.printf(0, 9, id(arimo10), "CO2: %.0f", id(co2).state);
+          it.printf(0, 18, id(arimo10), "PM1: %.0f", id(pm10).state);
+          it.printf(0, 27, id(arimo10), "PM2.5: %.0f", id(pm25).state);
+          it.printf(0, 36, id(arimo10), "PM10: %.0f", id(pm100).state);
+          it.printf(0, 45, id(arimo10), "TEMP: %.0fC HUM: %.0f%%", id(temp).state, id(humidity).state);
+
+# Provide a /metrics endpoint for Prometheus
+prometheus:
+web_server:
+  port: 9926
+  version: 1
+
+# Set an interval to loop through the OLED screens.
+interval:
+  - interval: 5s
+    then:
+      - display.page.show_next: oled
+      - component.update: oled
+
+uart:
+  - rx_pin: D5
+    tx_pin: D6
+    baud_rate: 9600
+    id: uart1
+  - rx_pin: D4
+    tx_pin: D3
+    baud_rate: 9600
+    id: uart2
+
+sensor:
+  - platform: sht3xd
+    temperature:
+      id: temp
+      name: "Temperature"
+    humidity:
+      id: humidity
+      name: "Humidity"
+    address: 0x44
+    update_interval: 5s
+
+  - platform: pmsx003
+    # type can be PMSX003, PMS5003S, PMS5003T, PMS5003ST
+    # https://esphome.io/components/sensor/pmsx003.html
+    type: PMSX003
+    uart_id: uart1
+    pm_1_0:
+      id: pm10
+      name: "Particulate Matter <1.0µm Concentration"
+    pm_2_5:
+      id: pm25
+      name: "Particulate Matter <2.5µm Concentration"
+    update_interval: 60s
+    pm_10_0:
+      id: pm100
+      name: "Particulate Matter <10.0µm Concentration"
+# If you have a version of the PMS*003* sensor that supports formaldehyde, uncomment the below block
+#    formaldehyde:
+#      id: hcho
+#      name: "Formaldehyde (HCHO) concentration in µg per cubic meter"
+
+  - platform: senseair
+    uart_id: uart2
+    co2:
+      id: co2
+      name: "CO2 level"
+    update_interval: 60s


### PR DESCRIPTION
The only difference is in the flipped, larger OLED screen and the I2C frequency change required by it.