### PR TITLE
SGP41 sensor support

### DIFF
--- a/.github/workflows/arduino.yaml
+++ b/.github/workflows/arduino.yaml
@@ -24,9 +24,10 @@ jobs:
         run: |
           arduino-cli lib install "AirGradient Air Quality Sensor"
 
-      - name: Install SSD1306 Display Library
+      - name: Install U8g2lib display library
         run: |
-          arduino-cli lib install "ESP8266 and ESP32 OLED driver for SSD1306 displays"
+          arduino-cli lib install "U8g2"
+          # https://github.com/olikraus/u8g2
 
       - name: Compile Sketch
         run: arduino-cli compile --fqbn esp8266:esp8266:d1_mini ./AirGradient-DIY

--- a/.github/workflows/arduino.yaml
+++ b/.github/workflows/arduino.yaml
@@ -24,6 +24,21 @@ jobs:
         run: |
           arduino-cli lib install "AirGradient Air Quality Sensor"
 
+      - name: Install Sensirion Core
+        run: |
+          arduino-cli lib install "Sensirion Core"
+          # https://github.com/Sensirion/arduino-core/
+
+      - name: Install Sensirion I2C SGP41
+        run: |
+          arduino-cli lib install "Sensirion I2C SGP41"
+          # https://github.com/Sensirion/arduino-i2c-sgp41
+
+      - name: Install Sensirion Gas Index Algorithm
+        run: |
+          arduino-cli lib install "Sensirion Gas Index Algorithm"
+          # https://github.com/Sensirion/arduino-gas-index-algorithm 
+
       - name: Install U8g2lib display library
         run: |
           arduino-cli lib install "U8g2"

--- a/AirGradient-DIY/AirGradient-DIY.ino
+++ b/AirGradient-DIY/AirGradient-DIY.ino
@@ -25,6 +25,9 @@ int cond_NOx_count = 10;
 // Optional.
 const char* deviceId = "";
 
+// flip display orientation along horisontal axis, for older PRO conversion kits
+const bool flipDisplay = false;
+
 // set to 'C' to use Celcius, Farenheit if set otherwise
 const char temp_display = 'C';
 
@@ -102,6 +105,9 @@ void setup() {
   // Init Display.
   u8g2.setBusClock(100000);
   u8g2.begin();
+  if (flipDisplay) {
+    u8g2.setFlipMode(1); 
+  }
   updateOLEDString("Init", String(ESP.getChipId(), HEX), "");
 #endif  // SET_DISPLAY
 


### PR DESCRIPTION
AirGradient library does not yet support this module, so I have made a best-effort implementation and some housekeeping.

- Adds support and error handling for SGP41 module with compensation based on measured SHT values.
- Moves from SSD1306Wire display library to `U8g2lib`, as the reference implementation has nicer support for three-line legible display of metrics without cycling. Also seems to have out-of-the-box support for the SH1106 displays shipped with pre-PRO edition kits. 3 by 2, static display of metrics in my opinion superior, as you need not wait for the metric you want, to be shown.
- Adds flag to enable AQI conversion based on PM2.5 to be shown on display, PM2.5 is regardless the metric reported.
- Adds verbose flag to debug readings but not otherwise spam serial when in production. Errors are always printed. Spurious address is printed from AirGradient library every SHT-sample though.

I would appreciate a person with a SSD1306 display testing whether the `U8g2lib` works as expected.