### PR TITLE
Airgradient and SGP41 version bump refactor

### DIFF
--- a/.github/workflows/arduino.yaml
+++ b/.github/workflows/arduino.yaml
@@ -22,26 +22,26 @@ jobs:
 
       - name: Install AirGradient Library
         run: |
-          arduino-cli lib install "AirGradient Air Quality Sensor"
+          arduino-cli lib install "AirGradient Air Quality Sensor"@2.4.15
 
       - name: Install Sensirion Core
         run: |
-          arduino-cli lib install "Sensirion Core"
+          arduino-cli lib install "Sensirion Core"@0.6.0
           # https://github.com/Sensirion/arduino-core/
 
       - name: Install Sensirion I2C SGP41
         run: |
-          arduino-cli lib install "Sensirion I2C SGP41"
+          arduino-cli lib install "Sensirion I2C SGP41"@1.0.0
           # https://github.com/Sensirion/arduino-i2c-sgp41
 
       - name: Install Sensirion Gas Index Algorithm
         run: |
-          arduino-cli lib install "Sensirion Gas Index Algorithm"
+          arduino-cli lib install "Sensirion Gas Index Algorithm"@3.2.2
           # https://github.com/Sensirion/arduino-gas-index-algorithm 
 
       - name: Install U8g2lib display library
         run: |
-          arduino-cli lib install "U8g2"
+          arduino-cli lib install "U8g2"@2.34.22
           # https://github.com/olikraus/u8g2
 
       - name: Compile Sketch

--- a/AirGradient-DIY/AirGradient-DIY.ino
+++ b/AirGradient-DIY/AirGradient-DIY.ino
@@ -129,7 +129,7 @@ void setup() {
 
   uint16_t error;
   char errorMessage[256];
-  error = sgp41.getSerialNumber(serialNumber, serialNumberSize);
+  error = sgp41.getSerialNumber(serialNumber);
 
   if (error) {
     Serial.print("Error trying to execute getSerialNumber(): ");

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ MIT.
 
   - [Jeff Geerling](https://www.jeffgeerling.com)
   - [Jordan Jones](https://github.com/kashalls)
+  - [Falke Carlsen](https://github.com/falkecarlsen)
 
 ESPHome configuration adapted from code by:
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ This project configures the AirGradient sensor for local access (instead of deli
 
 Please see the README file in the respective configuration folder for more information about how to set up your AirGradient sensor.
 
+## Contributing
+If you are adding a new library or bumping the version of an existing one, update the GitHub action [Arduino CI (`arduino.yaml`)](.github/workflows/arduino.yaml) accordingly.
+
 ## License
 
 MIT.


### PR DESCRIPTION
Related to SGP41 feature in #37.

AirGradient pushed a major update to their library sometime since submission of #37 and recent merge of #37. 
This should instigate a rewrite of the DIY sketch to align with new interfaces and do some cleanup but I do not have the time to do it now. 

As a stop-gap, I've pinned all libraries on the most recent, compiling version as per today. I've written a contributing notice in the main README.md about library versions - and added my name to the authors :)