### PR TITLE
Update to support ESPHome breaking change

### DIFF
--- a/AirGradient-ESPHome/airgradient-diy-pro.yaml
+++ b/AirGradient-ESPHome/airgradient-diy-pro.yaml
@@ -12,7 +12,8 @@ api:
     key: !secret api_encryption_key
 
 ota:
-  password: !secret ota_password
+ - platform: esphome
+   password: !secret ota_password
 
 # See: https://community.home-assistant.io/t/esphome-flashing-over-wifi-does-not-work/357352
 switch:

--- a/AirGradient-ESPHome/airgradient-diy.yaml
+++ b/AirGradient-ESPHome/airgradient-diy.yaml
@@ -12,7 +12,8 @@ api:
     key: !secret api_encryption_key
 
 ota:
-  password: !secret ota_password
+ - platform: esphome
+   password: !secret ota_password
 
 # See: https://community.home-assistant.io/t/esphome-flashing-over-wifi-does-not-work/357352
 switch:

--- a/AirGradient-ESPHome/airgradient-one.yaml
+++ b/AirGradient-ESPHome/airgradient-one.yaml
@@ -33,7 +33,8 @@ api:
     key: !secret api_encryption_key
 
 ota:
-  password: !secret ota_password
+ - platform: esphome
+   password: !secret ota_password
 
 wifi:
   ssid: !secret wifi_ssid


### PR DESCRIPTION
Fixes the "At least one platform must be specified for ‚ota‘; add ‚platform: esphome‘ for original OTA functionality“ error while running the file. The breaking change is a part of ESPHome 2024.6.0, listed in the changelog [here](https://esphome.io/changelog/2024.6.0#ota-platforms)