### PR TITLE
PM2.5 reading erroneously causes error state

### DIFF
--- a/AirGradient-DIY/AirGradient-DIY.ino
+++ b/AirGradient-DIY/AirGradient-DIY.ino
@@ -220,7 +220,7 @@ uint8_t update() {
 #ifdef SET_PM
   {
     int value = ag.getPM2_Raw();
-    if (value) {
+    if (value >= 0) {
       value_pm = value;
       if (verbose) {
         Serial.println("pm: " + String(value_pm));
@@ -234,7 +234,7 @@ uint8_t update() {
 #ifdef SET_CO2
   {
     int value = ag.getCO2_Raw();
-    if (value > 0) {
+    if (value >= 0) {
       value_co2 = value;
       if (verbose) {
         Serial.println("co2: " + String(value_co2));


### PR DESCRIPTION
Noticed some gaps in my Prometheus data, and found out that a zero reading from the PM2.5 sensor will cause the signal to appear to drop out. Made that change for the CO2 also, because there's no engineering like over-engineering

As a side effect, it looks like readings from `GetPM2_Raw()` that were supposed to be erroneous, would get through the check, since -1 was not captured by the `if` trap. My guess to the cause is the original implementation was expecting a NULL value out, and saw that `AirGradient::getPM2()` would return null on error, and mistakenly read that, rather than `AirGradient::getPM2_Raw()`

Hope this helps someone